### PR TITLE
Removed auto oAuth provider account linking of same emails

### DIFF
--- a/app/(auth)/login/authError.tsx
+++ b/app/(auth)/login/authError.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { authjsErrorDocsPageURL } from "@/auth.config";
+import FormErrorMsg from "@/components/formErrorMsg";
+import type { locale_content_type } from "@/public/locales/interface";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+const AuthError = ({ locale }: { locale: locale_content_type }) => {
+	const searchParams = useSearchParams();
+	const [errorCode, setErrorCode] = useState<null | undefined | string>(searchParams.get("error"));
+
+	let errorMsg = errorCode;
+
+	try {
+		errorMsg = locale.auth?.errors[errorCode] || errorCode;
+	} catch (error) {
+		// Just chill :)
+	}
+
+	useEffect(() => {
+		setErrorCode(searchParams.get("error"));
+	}, [searchParams]);
+
+	return (
+		errorCode && (
+			<FormErrorMsg>
+				<div className="flex flex-col items-end justify-center">
+					<p className="text-left">
+						{errorMsg}
+						<a
+							rel="noreferrer"
+							target="_blank"
+							href={`${authjsErrorDocsPageURL}#${errorCode.toLowerCase()}`}
+							className="text-xs text-foreground dark:text-foreground_muted_dark pl-2"
+						>
+							Learn more
+						</a>
+					</p>
+				</div>
+			</FormErrorMsg>
+		)
+	);
+};
+
+export default AuthError;

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -6,14 +6,15 @@
 //
 //   You should have received a copy of the GNU General Public License along with Cosmic Reach Mod Manager. If not, see <https://www.gnu.org/licenses/>.
 
-import React, { Suspense } from "react";
-import Link from "next/link";
 import AuthProviders from "@/app/(auth)/authproviders";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import LoginForm from "./Form";
 import LoadingUI from "@/components/ui/spinner";
 import { get_locale } from "@/lib/lang";
 import getLangPref from "@/lib/server/getLangPref";
+import Link from "next/link";
+import { Suspense } from "react";
+import LoginForm from "./Form";
+import AuthError from "./authError";
 
 const LoginPage = async () => {
 	const langPref = getLangPref();
@@ -22,6 +23,9 @@ const LoginPage = async () => {
 	return (
 		<div className="w-full flex items-center justify-center ">
 			<div className="flex w-full max-w-md flex-col gap-4 rounded-large">
+				<Suspense fallback={<LoadingUI />}>
+					<AuthError locale={locale} />
+				</Suspense>
 				<Card className="relative">
 					<CardHeader className="w-full flex items-center justify-start">
 						<h1 className="w-full text-left text-xl">{locale.auth.login}</h1>

--- a/app/(main)/(user)/settings/account/account_security/DeleteAccount.tsx
+++ b/app/(main)/(user)/settings/account/account_security/DeleteAccount.tsx
@@ -8,16 +8,16 @@
 //
 //   You should have received a copy of the GNU General Public License along with Cosmic Reach Mod Manager. If not, see <https://www.gnu.org/licenses/>.
 
-import { Button } from "@/components/ui/button";
-import { TrashIcon } from "@/components/Icons";
-import { useToast } from "@/components/ui/use-toast";
-import React, { useState } from "react";
-import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { DialogTrigger } from "@radix-ui/react-dialog";
 import { initiateDeleteAccountAction } from "@/app/api/actions/user";
-import { Spinner } from "@/components/ui/spinner";
+import { TrashIcon } from "@/components/Icons";
 import FormErrorMsg from "@/components/formErrorMsg";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { useToast } from "@/components/ui/use-toast";
 import type { locale_content_type } from "@/public/locales/interface";
+import { DialogTrigger } from "@radix-ui/react-dialog";
+import { useState } from "react";
 
 type Props = {
 	locale: locale_content_type;
@@ -58,7 +58,15 @@ const DeleteAccountSection = ({ locale }: Props) => {
 					{locale.settings_page.account_section.account_deletion_desc}
 				</p>
 			</div>
-			<Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+			<Dialog
+				open={dialogOpen}
+				onOpenChange={(open: boolean) => {
+					if (open === false) {
+						setFormError("");
+					}
+					setDialogOpen(open);
+				}}
+			>
 				<DialogTrigger asChild>
 					<Button className="flex items-center justify-center gap-2 bg-danger dark:bg-danger_dark hover:bg-danger/90 hover:dark:bg-danger_dark/90 text-foreground_dark hover:text-foreground_dark dark:text-foreground_dark">
 						<TrashIcon size="1rem" />

--- a/app/(main)/(user)/settings/account/account_security/ProvidersList.tsx
+++ b/app/(main)/(user)/settings/account/account_security/ProvidersList.tsx
@@ -8,21 +8,21 @@
 //
 //   You should have received a copy of the GNU General Public License along with Cosmic Reach Mod Manager. If not, see <https://www.gnu.org/licenses/>.
 
-import type React from "react";
-import { useState } from "react";
-import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
-import { Spinner } from "@/components/ui/spinner";
-import { Button } from "@/components/ui/button";
-import { ArrowTopRightIcon } from "@radix-ui/react-icons";
+import authProvidersList from "@/app/(auth)/avaiableAuthProviders";
 import { linkAuthProvider, unlinkAuthProvider } from "@/app/api/actions/user";
+import { TrashIcon } from "@/components/Icons";
 import FormErrorMsg from "@/components/formErrorMsg";
 import FormSuccessMsg from "@/components/formSuccessMsg";
-import { TrashIcon } from "@/components/Icons";
-import type { Account } from "@prisma/client";
-import authProvidersList from "@/app/(auth)/avaiableAuthProviders";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { locale_content_type } from "@/public/locales/interface";
+import type { Account } from "@prisma/client";
+import { ArrowTopRightIcon } from "@radix-ui/react-icons";
+import type React from "react";
+import { useState } from "react";
 
 type Props = {
 	id: string;
@@ -82,7 +82,16 @@ const ProvidersList = ({ id, linkedProviders, children, locale }: Props) => {
 	};
 
 	return (
-		<Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+		<Dialog
+			open={dialogOpen}
+			onOpenChange={(open: boolean) => {
+				if (open === false) {
+					setFormError("");
+					setSuccessMessage("");
+				}
+				setDialogOpen(open);
+			}}
+		>
 			<DialogTrigger asChild>{children}</DialogTrigger>
 
 			<DialogContent autoFocus={false}>

--- a/app/(main)/(user)/settings/account/account_security/addPasswordForm.tsx
+++ b/app/(main)/(user)/settings/account/account_security/addPasswordForm.tsx
@@ -8,25 +8,24 @@
 //
 //   You should have received a copy of the GNU General Public License along with Cosmic Reach Mod Manager. If not, see <https://www.gnu.org/licenses/>.
 
+import type { locale_content_type } from "@/public/locales/interface";
 import type React from "react";
-import { useState } from "react";
-import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
-import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+import { initiateAddNewPasswordAction } from "@/app/api/actions/user";
+import { KeyIcon } from "@/components/Icons";
+import FormErrorMsg from "@/components/formErrorMsg";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogClose, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { useToast } from "@/components/ui/use-toast";
 import { Spinner } from "@/components/ui/spinner";
-import { DialogClose } from "@/components/ui/dialog";
-
-import { Button } from "@/components/ui/button";
-import { KeyIcon } from "@/components/Icons";
+import { useToast } from "@/components/ui/use-toast";
 import { maxPasswordLength, minPasswordLength } from "@/config";
-import { initiateAddNewPasswordAction } from "@/app/api/actions/user";
 import { isValidPassword } from "@/lib/user";
-import FormErrorMsg from "@/components/formErrorMsg";
-import type { locale_content_type } from "@/public/locales/interface";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
 
 type Props = {
 	id: string;
@@ -113,7 +112,16 @@ const AddPasswordForm = ({ id, email, locale }: Props) => {
 	};
 
 	return (
-		<Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+		<Dialog
+			open={dialogOpen}
+			onOpenChange={(open: boolean) => {
+				if (open === false) {
+					form.reset();
+					setFormError("");
+				}
+				setDialogOpen(open);
+			}}
+		>
 			<DialogTrigger asChild>
 				<Button className="flex items-center justify-center gap-2" variant="outline">
 					<KeyIcon size="1.1rem" />

--- a/app/(main)/(user)/settings/account/account_security/removePasswordForm.tsx
+++ b/app/(main)/(user)/settings/account/account_security/removePasswordForm.tsx
@@ -8,23 +8,22 @@
 //
 //   You should have received a copy of the GNU General Public License along with Cosmic Reach Mod Manager. If not, see <https://www.gnu.org/licenses/>.
 
-import type React from "react";
-import { useState } from "react";
-import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
-import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogClose, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { useToast } from "@/components/ui/use-toast";
 import { Spinner } from "@/components/ui/spinner";
-import { DialogClose } from "@/components/ui/dialog";
+import { useToast } from "@/components/ui/use-toast";
+import { zodResolver } from "@hookform/resolvers/zod";
+import type React from "react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
 
+import { removePassword } from "@/app/api/actions/user";
+import { TrashIcon } from "@/components/Icons";
+import FormErrorMsg from "@/components/formErrorMsg";
 import { Button } from "@/components/ui/button";
 import { minPasswordLength } from "@/config";
-import { removePassword } from "@/app/api/actions/user";
-import FormErrorMsg from "@/components/formErrorMsg";
-import { TrashIcon } from "@/components/Icons";
 import type { locale_content_type } from "@/public/locales/interface";
 
 type Props = {
@@ -78,7 +77,16 @@ const RemovePasswordForm = ({ id, email, children, locale }: Props) => {
 	};
 
 	return (
-		<Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+		<Dialog
+			open={dialogOpen}
+			onOpenChange={(open: boolean) => {
+				if (open === false) {
+					form.reset();
+					setFormError("");
+				}
+				setDialogOpen(open);
+			}}
+		>
 			<DialogTrigger asChild>{children}</DialogTrigger>
 
 			<DialogContent>

--- a/app/(main)/(user)/settings/account/page.tsx
+++ b/app/(main)/(user)/settings/account/page.tsx
@@ -45,7 +45,7 @@ const AccountSettingsPage = async () => {
 						<h2 className="flex text-left text-2xl text-foreground/80 dark:text-foreground_dark/80">
 							{locale.settings_page.account_section.user_profile}
 						</h2>
-						<div>
+						<div className="flex h-full items-center justify-center">
 							<EditProfileDialog
 								name={user.name}
 								username={user.userName}

--- a/app/(main)/(user)/settings/account/profile/EditForm.tsx
+++ b/app/(main)/(user)/settings/account/profile/EditForm.tsx
@@ -33,6 +33,7 @@ type Props = {
 	username: string;
 	linkedProviders: Providers[];
 	currProfileProvider: Providers;
+	dialogOpen: boolean;
 	setDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
 	locale: locale_content_type;
 };
@@ -42,6 +43,7 @@ const EditProfileInfoForm = ({
 	username,
 	linkedProviders,
 	currProfileProvider,
+	dialogOpen,
 	setDialogOpen,
 	locale,
 }: Props) => {

--- a/app/(main)/(user)/settings/account/profile/editProfileDialog.tsx
+++ b/app/(main)/(user)/settings/account/profile/editProfileDialog.tsx
@@ -9,13 +9,13 @@
 //   You should have received a copy of the GNU General Public License along with Cosmic Reach Mod Manager. If not, see <https://www.gnu.org/licenses/>.
 
 import { Dialog, DialogTrigger } from "@/components/ui/dialog";
-import React, { useState } from "react";
+import { useState } from "react";
 
-import EditProfileInfoForm from "./EditForm";
-import { Button } from "@/components/ui/button";
-import type { Providers } from "@prisma/client";
 import { EditIcon } from "@/components/Icons";
+import { Button } from "@/components/ui/button";
 import type { locale_content_type } from "@/public/locales/interface";
+import type { Providers } from "@prisma/client";
+import EditProfileInfoForm from "./EditForm";
 
 type Props = {
 	name: string;
@@ -47,6 +47,7 @@ const EditProfileDialog = ({ name, username, linkedProviders, currProfileProvide
 					username={username}
 					linkedProviders={linkedProviders}
 					currProfileProvider={currProfileProvider}
+					dialogOpen={dialogOpen}
 					setDialogOpen={setDialogOpen}
 					locale={locale}
 				/>

--- a/app/api/actions/user.ts
+++ b/app/api/actions/user.ts
@@ -9,8 +9,16 @@
 //   You should have received a copy of the GNU General Public License along with Cosmic Reach Mod Manager. If not, see <https://www.gnu.org/licenses/>.
 
 import { auth, signIn } from "@/auth";
+import {
+	addNewPasswordVerificationTokenValidity_ms,
+	changePasswordConfirmationTokenValidity_ms,
+	deleteAccountVerificationTokenValidity_ms,
+	deletedUsernameReservationDuration_ms,
+	passwordHashingSaltRounds,
+} from "@/config";
 import db from "@/lib/db";
-import bcrypt from "bcrypt";
+import { get_locale } from "@/lib/lang";
+import getLangPref from "@/lib/server/getLangPref";
 import {
 	isValidName,
 	isValidPassword,
@@ -20,30 +28,20 @@ import {
 	parseUserName,
 } from "@/lib/user";
 import {
+	UserVerificationActionTypes,
 	type Account,
 	type Providers,
 	type User,
-	UserVerificationActionTypes,
 	type VerificationEmail,
 } from "@prisma/client";
+import bcrypt from "bcrypt";
 import { revalidatePath } from "next/cache";
-import {
-	changePasswordConfirmationTokenValidity_ms,
-	addNewPasswordVerificationTokenValidity_ms,
-	deleteAccountVerificationTokenValidity_ms,
-	passwordHashingSaltRounds,
-	deletedUsernameReservationDuration_ms,
-	dbSessionTokenCookieKeyName,
-} from "@/config";
+import { getAuthenticatedUser } from "./auth";
 import {
 	sendAccountDeletionConfirmationEmail,
 	sendNewPasswordVerificationEmail,
 	sendPasswordChangeEmail,
 } from "./verificationEmails";
-import { getAuthenticatedUser } from "./auth";
-import { get_locale } from "@/lib/lang";
-import getLangPref from "@/lib/server/getLangPref";
-import { cookies } from "next/headers";
 
 // Hash the user password using bcrypt
 const hashPassword = async (password: string) => {
@@ -318,7 +316,7 @@ export const loginUser = async ({
 	if (!userData?.email) {
 		return {
 			success: false,
-			message: locale.api_responses.user.no_account_exists_with_that_email,
+			message: locale.api_responses.user.incorrect_email_or_pass,
 		};
 	}
 

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -6,29 +6,28 @@
 //
 //   You should have received a copy of the GNU General Public License along with Cosmic Reach Mod Manager. If not, see <https://www.gnu.org/licenses/>.
 
-import GitHubProvider from "next-auth/providers/github";
-import DiscordProvider from "next-auth/providers/discord";
-import GoogleProvider from "@auth/core/providers/google";
-import GitlabProvider from "@auth/core/providers/gitlab";
 import type { NextAuthConfig } from "next-auth";
+import DiscordProvider from "next-auth/providers/discord";
+import GitHubProvider from "next-auth/providers/github";
+import GitlabProvider from "next-auth/providers/gitlab";
+import GoogleProvider from "next-auth/providers/google";
+
+export const authjsErrorDocsPageURL = "https://authjs.dev/reference/core/errors";
 
 export default {
 	providers: [
 		GitHubProvider({
 			clientId: process.env.GITHUB_ID,
 			clientSecret: process.env.GITHUB_SECRET,
-			allowDangerousEmailAccountLinking: true,
 		}),
 		DiscordProvider({
 			clientId: process.env.DISCORD_ID,
 			clientSecret: process.env.DISCORD_SECRET,
-			allowDangerousEmailAccountLinking: true,
 		}),
 
 		GoogleProvider({
 			clientId: process.env.GOOGLE_ID,
 			clientSecret: process.env.GOOGLE_SECRET,
-			allowDangerousEmailAccountLinking: true,
 			authorization: {
 				params: {
 					prompt: "consent",
@@ -40,7 +39,6 @@ export default {
 		GitlabProvider({
 			clientId: process.env.GITLAB_ID,
 			clientSecret: process.env.GITLAB_SECRET,
-			allowDangerousEmailAccountLinking: true,
 		}),
 	],
 } satisfies NextAuthConfig;

--- a/auth.ts
+++ b/auth.ts
@@ -6,17 +6,17 @@
 //
 //   You should have received a copy of the GNU General Public License along with Cosmic Reach Mod Manager. If not, see <https://www.gnu.org/licenses/>.
 
-import db from "@/lib/db";
-import NextAuth from "next-auth";
+import { findUserByEmail, findUserById, matchPassword } from "@/app/api/actions/user";
 import authConfig from "@/auth.config";
-import CredentialsProvider from "next-auth/providers/credentials";
+import db from "@/lib/db";
+import { parseProfileProvider, parseUsername } from "@/lib/user";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import type { DeletedUser, Providers, UserRoles } from "@prisma/client";
-import { findUserByEmail, findUserById, matchPassword } from "@/app/api/actions/user";
-import { parseProfileProvider, parseUsername } from "@/lib/user";
-import { dbSessionTokenCookieKeyName, maxUsernameLength } from "./config";
+import NextAuth from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
 import { cookies } from "next/headers";
 import { deleteSessionToken, setSessionToken } from "./app/api/actions/auth";
+import { dbSessionTokenCookieKeyName, maxUsernameLength } from "./config";
 
 declare module "next-auth" {
 	// Additional types in the User field
@@ -155,6 +155,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 	},
 
 	secret: process.env.AUTH_SECRET,
+
+	pages: {
+		signIn: "/login",
+		// newUser: "/onboarding",
+	},
 
 	providers: [
 		...authConfig.providers,

--- a/components/Navbar/AuthButton/SignOutBtn.tsx
+++ b/components/Navbar/AuthButton/SignOutBtn.tsx
@@ -9,12 +9,11 @@
 //   You should have received a copy of the GNU General Public License along with Cosmic Reach Mod Manager. If not, see <https://www.gnu.org/licenses/>.
 
 import { LogoutIcon } from "@/components/Icons";
-import { signOut } from "next-auth/react";
-import { useRouter } from "next/navigation";
-import React, { useState } from "react";
-import ProfileDropdownLink from "./ProfileDropdownLink";
 import { Spinner } from "@/components/ui/spinner";
 import type { auth_locale } from "@/public/locales/interface";
+import { signOut } from "next-auth/react";
+import { useState } from "react";
+import ProfileDropdownLink from "./ProfileDropdownLink";
 
 type Props = {
 	authLocale: auth_locale;
@@ -22,15 +21,12 @@ type Props = {
 };
 
 const SignOutBtn = ({ className, authLocale }: Props) => {
-	const router = useRouter();
 	const [loading, setLoading] = useState(false);
 
 	const handleClick = async () => {
 		if (loading) return;
 		setLoading(true);
 		await signOut();
-		setLoading(false);
-		router.push("/login");
 	};
 
 	return (

--- a/components/formErrorMsg.tsx
+++ b/components/formErrorMsg.tsx
@@ -1,14 +1,14 @@
 import { cn } from "@/lib/utils";
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
-import React from "react";
 
 type Props = {
-	msg: string;
+	children?: React.ReactNode;
+	msg?: string;
 	className?: string;
 	iconClassName?: string;
 };
 
-const FormErrorMsg = ({ msg, className, iconClassName }: Props) => {
+const FormErrorMsg = ({ children, msg, className, iconClassName }: Props) => {
 	return (
 		<div
 			className={cn(
@@ -17,7 +17,7 @@ const FormErrorMsg = ({ msg, className, iconClassName }: Props) => {
 			)}
 		>
 			<ExclamationTriangleIcon className={cn("pl-1 w-5 h-4 shrink-0", iconClassName)} />
-			<p>{msg}</p>
+			{children ? children : <p className="text-left">{msg}</p>}
 		</div>
 	);
 };

--- a/contexts/StoreContext.tsx
+++ b/contexts/StoreContext.tsx
@@ -17,9 +17,13 @@ type StoreContextValues = {
 	isDesktop: boolean;
 };
 
-export const StoreContext = createContext({
+export const StoreContext = createContext<StoreContextValues | null>({
 	isNavMenuOpen: false,
-} as StoreContextValues);
+	toggleNavMenu: (newState?: boolean) => {
+		return;
+	},
+	isDesktop: false,
+});
 
 export default function StoreContextProvider({ children }: { children: React.ReactNode }) {
 	const [isNavMenuOpen, setIsNavMenuOpen] = useState<boolean>(false);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"dev": "next dev --turbo",
+		"dev": "next dev",
 		"build": "npx prisma generate && next build",
 		"start": "next start",
 		"lint": "next lint"

--- a/public/locales/en/en-GB.ts
+++ b/public/locales/en/en-GB.ts
@@ -90,6 +90,11 @@ export const en_gb = {
 			signing_out: "Signing out",
 			something_went_wrong: "Something went wrong",
 
+			errors: {
+				OAuthAccountNotLinked:
+					"The email address is already associated with an account but you are trying to use an OAuth account that is not linked to it.",
+			},
+
 			login_page: {
 				meta_desc: "Log into cosmic reach mod manager to get a more personalized experience.",
 				dont_have_an_account: "Don't have an account?",

--- a/public/locales/es/es-ES.ts
+++ b/public/locales/es/es-ES.ts
@@ -80,6 +80,10 @@ export const es_es: locale_variant_object = {
 			signing_out: "Cerrando sesión",
 			something_went_wrong: "Algo salió mal",
 
+			errors: {
+				OAuthAccountNotLinked: null,
+			},
+
 			login_page: {
 				meta_desc:
 					"Inicia sesión en el administrador de mods de Cosmic Reach para obtener una experiencia más personalizada.",

--- a/public/locales/no/no-NB.ts
+++ b/public/locales/no/no-NB.ts
@@ -79,6 +79,10 @@ export const no_nb: locale_variant_object = {
 			signing_out: "Logger ut",
 			something_went_wrong: "Noe gikk galt",
 
+			errors: {
+				OAuthAccountNotLinked: null,
+			},
+
 			login_page: {
 				meta_desc: "Logg inn i Cosmic Reach Mod Manager for å få en mer personlig opplevelse.",
 				dont_have_an_account: "Har du ikke en konto?",

--- a/public/locales/no/no-NN.ts
+++ b/public/locales/no/no-NN.ts
@@ -79,6 +79,10 @@ export const no_nn: locale_variant_object = {
 			signing_out: "Loggar ut",
 			something_went_wrong: "Noko gjekk gale",
 
+			errors: {
+				OAuthAccountNotLinked: null,
+			},
+
 			login_page: {
 				meta_desc: "Logg inn i Cosmic Reach Mod Manager for å få ei meir personleg oppleving.",
 				dont_have_an_account: "Har du ikkje ein konto?",

--- a/public/locales/ru/ru-RU.ts
+++ b/public/locales/ru/ru-RU.ts
@@ -78,6 +78,10 @@ export const ru_ru: locale_variant_object = {
 			signing_out: "Выходим",
 			something_went_wrong: "Что-то пошло не так",
 
+			errors: {
+				OAuthAccountNotLinked: null,
+			},
+
 			login_page: {
 				meta_desc: "Войдите в Менеджер Модов Cosmic Reach, чтобы получить доступ к новым возможностям.",
 				dont_have_an_account: "Не зарегистрированы?",


### PR DESCRIPTION
Remove the auto oAuth provider account linking  behaviour, auth provider accounts can now only be linked manually. Any oAuth account of the same email that is not linked will not be able to log in directly.