### PR TITLE
Noticed there where no space between the translation for "license" and the license link.

### DIFF
--- a/apps/frontend/app/locales/no-nb/translation.ts
+++ b/apps/frontend/app/locales/no-nb/translation.ts
@@ -324,7 +324,7 @@ export default {
         project: "Prosjekt",
         details: "Detaljer",
         licensed: (license) => [
-            "LISENS",
+            "LISENS ",
             license,
         ],
         updatedAt: (when) => `Oppdatert ${when}`,


### PR DESCRIPTION
I noticed there where no space between the translation for "license" and the license link, so I fixed that.
But when I went here to GitHub, noticed that the link on the right on the front page is to the old domain.

<img width="898" height="489" alt="image" src="https://github.com/user-attachments/assets/69963667-222e-4989-b218-9c5f5b209b52" />